### PR TITLE
Parse body params lazily

### DIFF
--- a/src/dsl.cr
+++ b/src/dsl.cr
@@ -58,7 +58,6 @@ module Artanis
 
       def {{ type.id }}_{{ method_name.id }}(matchdata)
         parse_query_params
-        parse_body_params
 
         {{ path }}
           .scan(FIND_PARAM_NAME)
@@ -177,13 +176,6 @@ module Artanis
       if !@query_parsed && query
         HTTP::Params.parse(query) { |key, value| @params[key] = value }
         @query_parsed = true
-      end
-    end
-
-    private def parse_body_params
-      return unless request.headers["Content-Type"]? == "application/x-www-form-urlencoded"
-      if body = request.body
-        HTTP::Params.parse(body.gets_to_end) { |key, value| @params[key] = value }
       end
     end
   end

--- a/test/dsl_test.cr
+++ b/test/dsl_test.cr
@@ -136,6 +136,13 @@ class Artanis::DSLTest < Minitest::Test
     assert_equal({ "id" => "123", "q" => "term", "lang" => "fr" }, JSON.parse(response.body).as_h)
   end
 
+  def test_encoded_body
+    response = call "POST", "/params_body?id=789&lang=fr",
+      headers: HTTP::Headers{ "Content-Type" => "application/x-www-form-urlencoded" },
+      body: "q=term&id=123"
+    assert_equal({ "body" => "q=term&id=123", "id" => "789", "lang" => "fr" }, JSON.parse(response.body).as_h)
+  end
+
   def call(request, method, headers = nil, body = nil)
     App.call(context(request, method, io: nil, headers: headers, body: body))
   end

--- a/test/test_helper.cr
+++ b/test/test_helper.cr
@@ -148,4 +148,8 @@ class App < Artanis::Application
   post "/params" do
     params.to_json
   end
+
+  post "/params_body" do
+    {"body" => request.body.try &.gets_to_end}.merge(params).to_json
+  end
 end


### PR DESCRIPTION
So they don't consume the body IO in case the caller wants to.

The spec depends on https://github.com/crystal-lang/crystal/pull/4415